### PR TITLE
Ignore unknown flags

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,41 +2,49 @@ package main
 
 import (
 	"crypto/tls"
-	"flag"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 
+	"github.com/jessevdk/go-flags"
 	"github.com/quic-go/perf"
 )
+
+type Options struct {
+	RunServer      bool    `long:"run-server" description:"run as server, default: false"`
+	ServerAddress  string  `long:"server-address" description:"server address, required"`
+	UploadBytes    uint64  `long:"upload-bytes" description:"upload bytes"`
+	DownloadBytes  uint64  `long:"download-bytes" description:"download bytes"`
+}
 
 var tlsConf *tls.Config
 
 func main() {
-	server := flag.Bool("run-server", false, "run as server, default: false")
-	serverAddr := flag.String("server-address", "", "server address, required")
-	uploadBytes := flag.Uint64("upload-bytes", 0, "upload bytes")
-	downloadBytes := flag.Uint64("download-bytes", 0, "download bytes")
-	flag.Parse()
+	var opt Options
+	parser := flags.NewParser(&opt, flags.IgnoreUnknown)
+	_, err := parser.Parse()
+	if err != nil {
+		panic(err)
+	}
 
-	if *serverAddr == "" {
-		flag.Usage()
+	if opt.ServerAddress == "" {
+		parser.WriteHelp(os.Stdout)
 		os.Exit(1)
 	}
 
-	if *server {
+	if opt.RunServer {
 		go func() {
 			log.Println(http.ListenAndServe("0.0.0.0:6060", nil))
 		}()
-		if err := perf.RunServer(*serverAddr); err != nil {
+		if err := perf.RunServer(opt.ServerAddress); err != nil {
 			log.Fatal(err)
 		}
 	} else {
 		go func() {
 			log.Println(http.ListenAndServe("0.0.0.0:6061", nil))
 		}()
-		if err := perf.RunClient(*serverAddr, *uploadBytes, *downloadBytes); err != nil {
+		if err := perf.RunClient(opt.ServerAddress, opt.UploadBytes, opt.DownloadBytes); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
+	github.com/jessevdk/go-flags v1.5.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.2.0 // indirect
 	github.com/quic-go/qtls-go1-19 v0.3.2 // indirect
 	github.com/quic-go/qtls-go1-20 v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
+github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/onsi/ginkgo/v2 v2.2.0 h1:3ZNA3L1c5FYDFTTxbFeVGGD8jYvjYauHD30YgLxVsNI=
 github.com/onsi/ginkgo/v2 v2.2.0/go.mod h1:MEH45j8TBi6u9BMogfbp0stKC5cdGjumZj5Y7AG4VIk=
 github.com/onsi/gomega v1.20.1 h1:PA/3qinGoukvymdIDV8pii6tiZgC8kbmJO6Z5+b002Q=
@@ -48,6 +50,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=


### PR DESCRIPTION
Some of the command line flags provided by the `libp2p/test-plans/perf/runner` are irrelevant to the `quic-go/perf` implementation, e.g. the `--transport` flag. Instead of explicitly ignoring those flags, I suggest ignoring all unknown flags. As far as I can tell the `flag` package does not provide such option, but the `go-flags` does.

Mind switching to `go-flags` here @marten-seemann?