### PR TITLE
refactor(client): expose single latency measurement

### DIFF
--- a/client.go
+++ b/client.go
@@ -14,9 +14,7 @@ import (
 )
 
 type Result struct {
-	ConnectionEstablishedSeconds float64 `json:"connectionEstablishedSeconds"`
-	UploadSeconds                float64 `json:"uploadSeconds"`
-	DownloadSeconds              float64 `json:"downloadSeconds"`
+	Latency float64 `json:"latency"`
 }
 
 func RunClient(addr string, uploadBytes, downloadBytes uint64) error {
@@ -35,7 +33,6 @@ func RunClient(addr string, uploadBytes, downloadBytes uint64) error {
 	if err != nil {
 		return err
 	}
-	connectionEstablishmentTook := time.Since(start)
 	str, err := conn.OpenStream()
 	if err != nil {
 		return err
@@ -47,9 +44,7 @@ func RunClient(addr string, uploadBytes, downloadBytes uint64) error {
 	log.Printf("uploaded %s: %.2fs (%s/s)", formatBytes(uploadBytes), uploadTook.Seconds(), formatBytes(bandwidth(uploadBytes, uploadTook)))
 	log.Printf("downloaded %s: %.2fs (%s/s)", formatBytes(downloadBytes), downloadTook.Seconds(), formatBytes(bandwidth(downloadBytes, downloadTook)))
 	json, err := json.Marshal(Result{
-		ConnectionEstablishedSeconds: connectionEstablishmentTook.Seconds(),
-		UploadSeconds:                uploadTook.Seconds(),
-		DownloadSeconds:              downloadTook.Seconds(),
+		Latency: time.Since(start).Seconds(),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Instead of exposing the time to establish a connection, the time to upload the bytes and the time to download the bytes, expose a single time including all three.

The rational here is, that differentiation of the three is flawed. E.g. when does one stop the upload timer and start the download timer? When the last byte is sent? When the last byte is flushed? When the first byte is received?

See https://github.com/libp2p/test-plans/pull/184#pullrequestreview-1482600521 for past discussion.