### PR TITLE
support numbers with kmg suffix for command line options

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,7 +41,7 @@ func main() {
 		go func() {
 			log.Println(http.ListenAndServe("0.0.0.0:6061", nil))
 		}()
-		if err := perf.RunClient(opt.ServerAddress, perf.ToBytes(opt.UploadBytes), perf.ToBytes(opt.DownloadBytes)); err != nil {
+		if err := perf.RunClient(opt.ServerAddress, perf.ParseBytes(opt.UploadBytes), perf.ParseBytes(opt.DownloadBytes)); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,8 +13,8 @@ import (
 type Options struct {
 	RunServer     bool   `long:"run-server" description:"run as server, default: false"`
 	ServerAddress string `long:"server-address" description:"server address, required"`
-	UploadBytes   uint64 `long:"upload-bytes" description:"upload bytes"`
-	DownloadBytes uint64 `long:"download-bytes" description:"download bytes"`
+	UploadBytes   string `long:"upload-bytes" description:"upload bytes #[KMG]"`
+	DownloadBytes string `long:"download-bytes" description:"download bytes #[KMG]"`
 }
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 		go func() {
 			log.Println(http.ListenAndServe("0.0.0.0:6061", nil))
 		}()
-		if err := perf.RunClient(opt.ServerAddress, opt.UploadBytes, opt.DownloadBytes); err != nil {
+		if err := perf.RunClient(opt.ServerAddress, perf.ToBytes(opt.UploadBytes), perf.ToBytes(opt.DownloadBytes)); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/util.go
+++ b/util.go
@@ -2,8 +2,12 @@ package perf
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 )
+
+var kmgMap = map[string]uint64{"K": 1024, "M": 1024 * 1024, "G": 1024 * 1024 * 1024}
 
 func bandwidth(b uint64, d time.Duration) uint64 {
 	return uint64(float64(b) / d.Seconds())
@@ -20,4 +24,23 @@ func formatBytes(b uint64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+func ToBytes(input string) (output uint64) {
+	if len(input) == 0 {
+		return 0
+	}
+	var kmg uint64 = 1
+	for s, v := range kmgMap {
+		if strings.ToUpper(input[len(input)-1:]) == s {
+			input = input[:len(input)-1]
+			kmg = v
+			break
+		}
+	}
+	num, err := strconv.ParseUint(input, 10, 64)
+	if err != nil {
+		panic("invalid kmg number")
+	}
+	return num * kmg
 }

--- a/util.go
+++ b/util.go
@@ -26,8 +26,8 @@ func formatBytes(b uint64) string {
 	return fmt.Sprintf("%.1f %ciB", float64(b)/float64(div), "KMGTPE"[exp])
 }
 
-func ToBytes(input string) (output uint64) {
-	if len(input) == 0 {
+func ParseBytes(input string) uint64 {
+	if input == "" {
 		return 0
 	}
 	var kmg uint64 = 1


### PR DESCRIPTION
Like iperf3 

```
 -n, --bytes     #[KMG]    number of bytes to transmit (instead of -t)

[KMG] indicates options that support a K/M/G suffix for kilo-, mega-, or giga-
```
